### PR TITLE
[FIX] JWT필터에서 바로 memberSeq를 Principal에 저장하도록 수정

### DIFF
--- a/src/main/java/com/freshman/freshmanbackend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/freshman/freshmanbackend/domain/member/repository/MemberRepository.java
@@ -1,12 +1,14 @@
 package com.freshman.freshmanbackend.domain.member.repository;
 
 import com.freshman.freshmanbackend.domain.member.domain.Member;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * 멤버 JPA Repository
  */
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Member findByOauth2Id(String oauth2Id);
-    void deleteByOauth2Id(String oauth2Id);
+  void deleteByOauth2Id(String oauth2Id);
+
+  Member findByOauth2Id(String oauth2Id);
 }

--- a/src/main/java/com/freshman/freshmanbackend/global/auth/dto/CustomOauth2User.java
+++ b/src/main/java/com/freshman/freshmanbackend/global/auth/dto/CustomOauth2User.java
@@ -1,57 +1,47 @@
 package com.freshman.freshmanbackend.global.auth.dto;
 
-import com.freshman.freshmanbackend.domain.member.domain.Member;
-import com.freshman.freshmanbackend.domain.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
+
+import lombok.RequiredArgsConstructor;
 
 /**
  * 로그인 사용자 정보
  */
 @RequiredArgsConstructor
 public class CustomOauth2User implements OAuth2User {
-    private final OauthUserDto userDto;
-    private final MemberRepository memberRepository;
+  private final OauthUserDto userDto;
 
-    @Override
-    public Map<String, Object> getAttributes() {
-        return null;
-    }
+  @Override
+  public Map<String, Object> getAttributes() {
+    return null;
+  }
 
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        Collection<GrantedAuthority> collection = new ArrayList<>();
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    Collection<GrantedAuthority> collection = new ArrayList<>();
 
-        collection.add(new GrantedAuthority() {
-            @Override
-            public String getAuthority() {
+    collection.add(new GrantedAuthority() {
+      @Override
+      public String getAuthority() {
 
-                return userDto.getRole();
-            }
-        });
+        return userDto.getRole();
+      }
+    });
 
-        return collection;
-    }
+    return collection;
+  }
 
-    @Override
-    public String getName() {
-        return userDto.getOauth2Id();
-    }
+  public Long getMemberSeq() {
+    return userDto.getMemberSeq();
+  }
 
-    public Long getMemberSeq(){
-        Long memberSeq = userDto.getMemberSeq();
-        if (memberSeq == null){
-            Member member = memberRepository.findByOauth2Id(userDto.getOauth2Id());
-            userDto.setMemberSeq(member.getMemberSeq());
-            return member.getMemberSeq();
-        }
-        return memberSeq;
-    }
+  @Override
+  public String getName() {
+    return userDto.getOauth2Id();
+  }
 }

--- a/src/main/java/com/freshman/freshmanbackend/global/auth/filter/JwtFilter.java
+++ b/src/main/java/com/freshman/freshmanbackend/global/auth/filter/JwtFilter.java
@@ -4,14 +4,7 @@ import com.freshman.freshmanbackend.domain.member.repository.MemberRepository;
 import com.freshman.freshmanbackend.global.auth.dto.CustomOauth2User;
 import com.freshman.freshmanbackend.global.auth.dto.OauthUserDto;
 import com.freshman.freshmanbackend.global.auth.util.JwtUtil;
-import com.freshman.freshmanbackend.global.redis.service.RedisRefreshTokenService;
-import io.jsonwebtoken.ExpiredJwtException;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,59 +13,69 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
 /**
  * JWT 필터
  */
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
-    private final JwtUtil jwtUtil;
-    private final MemberRepository memberRepository;
+  private final JwtUtil jwtUtil;
+  private final MemberRepository memberRepository;
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
 
-        String accessToken = request.getHeader("Authorization");
-        if (accessToken == null || !accessToken.startsWith("Bearer ")) {
-            filterChain.doFilter(request, response);
-            return ;
-        }
-        accessToken = accessToken.substring(7);
-
-        try {
-            jwtUtil.isExpired(accessToken);
-        } catch (ExpiredJwtException e) {
-
-            PrintWriter writer = response.getWriter();
-            writer.print("access token expired");
-
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            return ;
-        }
-
-        String category = jwtUtil.getCategory(accessToken);
-        if (!category.equals("access_token")) {
-            PrintWriter writer = response.getWriter();
-            writer.print("invalid access token");
-
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            return;
-        }
-
-        //토큰에서 oauth2Id과 role 획득
-        String oauth2Id = jwtUtil.getOauth2Id(accessToken);
-        String role = jwtUtil.getRole(accessToken);
-
-        //userDTO를 생성하여 값 set
-        OauthUserDto userDTO = new OauthUserDto(null,oauth2Id,role);
-
-        //UserDetails에 회원 정보 객체 담기
-        CustomOauth2User customOAuth2User = new CustomOauth2User(userDTO,memberRepository);
-
-        //스프링 시큐리티 인증 토큰 생성
-        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
-        //세션에 사용자 등록
-        SecurityContextHolder.getContext().setAuthentication(authToken);
-
-        filterChain.doFilter(request, response);
+    String accessToken = request.getHeader("Authorization");
+    if (accessToken == null || !accessToken.startsWith("Bearer ")) {
+      filterChain.doFilter(request, response);
+      return;
     }
+    accessToken = accessToken.substring(7);
+
+    try {
+      jwtUtil.isExpired(accessToken);
+    } catch (ExpiredJwtException e) {
+
+      PrintWriter writer = response.getWriter();
+      writer.print("access token expired");
+
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      return;
+    }
+
+    String category = jwtUtil.getCategory(accessToken);
+    if (!category.equals("access_token")) {
+      PrintWriter writer = response.getWriter();
+      writer.print("invalid access token");
+
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      return;
+    }
+
+    //토큰에서 oauth2Id과 role 획득
+    String oauth2Id = jwtUtil.getOauth2Id(accessToken);
+    String role = jwtUtil.getRole(accessToken);
+    Long memberSeq = memberRepository.findByOauth2Id(oauth2Id).getMemberSeq();
+
+    //userDTO를 생성하여 값 set
+    OauthUserDto userDTO = new OauthUserDto(memberSeq, oauth2Id, role);
+
+    //UserDetails에 회원 정보 객체 담기
+    CustomOauth2User customOAuth2User = new CustomOauth2User(userDTO);
+
+    //스프링 시큐리티 인증 토큰 생성
+    Authentication authToken =
+        new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
+    //세션에 사용자 등록
+    SecurityContextHolder.getContext().setAuthentication(authToken);
+
+    filterChain.doFilter(request, response);
+  }
 }

--- a/src/main/java/com/freshman/freshmanbackend/global/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/freshman/freshmanbackend/global/auth/service/CustomOAuth2UserService.java
@@ -38,17 +38,17 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     } else {
       return null;
     }
-    
+
     String oauth2Id = oauth2Response.getProvider() + oauth2Response.getProviderId();
     Member member = memberRepository.findByOauth2Id(oauth2Id);
     if (member == null) { // 회원가입
       Member newMember = new Member(oauth2Id, Role.USER);
       Member savedMember = memberRepository.save(newMember);
       OauthUserDto userDto = new OauthUserDto(savedMember.getMemberSeq(), oauth2Id, Role.USER.getDesc());
-      return new CustomOauth2User(userDto, memberRepository);
+      return new CustomOauth2User(userDto);
     } else { // 로그인
       OauthUserDto userDto = new OauthUserDto(member.getMemberSeq(), oauth2Id, member.getRole().getDesc());
-      return new CustomOauth2User(userDto, memberRepository);
+      return new CustomOauth2User(userDto);
     }
   }
 }


### PR DESCRIPTION
### 기존 로직
- memberSeq이 필요할 때 DB에 접근해서 Principal에 캐싱 해두고 사용

### 수정된 로직
- JWT필터를 거칠 때 DB에 접근하여 memberSeq를 가져와서 Principal에 넣어두고 사용

### 변경 이유
- 후기 수정 api 수행중 JPA Auditing기능을 수행하게 되는데, AuditorAware에서 getMemberSeq()를 통해 memberRepository에 접근하게 되면 memberRepository에서도 getMemberSeq()를 호출하게 되어 StackOverflow가 발생한다.
- 따라서 Auditing 기능이 동작하는 중에 memberRepository에 접근하지 않도록 memberSeq를 필터단에서 입력하도록 변경했다.